### PR TITLE
Feat: Add DFIntCanHideGuiGroupId fastflag

### DIFF
--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -81,6 +81,7 @@ namespace linuxblox.viewmodels
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsPreferVulkan", Description = "Prefer Vulkan Renderer", IsOn = true });
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsDisablePostFX", Description = "Disable Post-Processing Effects", IsOn = false });
             Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", Value = "4" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID. If the user is a member of this group, enables: Ctrl+Shift+G (CoreGui), C (DevUI), B (3D GUI), N (Nameplates) to toggle visibility. Set to 0 to disable.", Value = "0" });
         }
 
         private async Task<string> LoadSettingsFromFileAsync()


### PR DESCRIPTION
This adds the `DFIntCanHideGuiGroupId` fastflag to the editor. This is an integer flag requiring a Group ID.

If the flag is set to a valid Group ID and you are a member of that group, the following keybinds are enabled to toggle GUI visibility:
- Ctrl+Shift+G: Toggles CoreGui elements
- Ctrl+Shift+C: Toggles ScreenGui elements (Developer UI)
- Ctrl+Shift+B: Toggles 3D Space GUI elements (BillboardGui, SurfaceGui)
- Ctrl+Shift+N: Toggles Player Nameplates

Setting the flag to 0 disables this functionality. The default value is 0.

You provided the detailed behavior of this flag, as it's an internal, undocumented Roblox feature.