### PR TITLE
refactor: Remove checkboxes for enabling/disabling flags

### DIFF
--- a/mainwindow.axaml
+++ b/mainwindow.axaml
@@ -37,18 +37,16 @@
                BorderThickness="0">
         <ListBox.DataTemplates>
           <DataTemplate DataType="{x:Type vm:InputFlagViewModel}">
-            <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,5">
-              <CheckBox Grid.Column="0" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center"/>
-              <TextBlock Grid.Column="1" Text="{Binding Description}" VerticalAlignment="Center" Margin="10,0"/>
-              <TextBox Grid.Column="2" Text="{Binding Value}" MinWidth="100" IsEnabled="{Binding IsEnabled}"/>
+            <Grid ColumnDefinitions="*,Auto" Margin="0,5">
+              <TextBlock Grid.Column="0" Text="{Binding Description}" VerticalAlignment="Center" Margin="10,0"/>
+              <TextBox Grid.Column="1" Text="{Binding Value}" MinWidth="100" IsEnabled="{Binding IsEnabled}"/>
             </Grid>
           </DataTemplate>
           
           <DataTemplate DataType="{x:Type vm:ToggleFlagViewModel}">
-            <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,5">
-              <CheckBox Grid.Column="0" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center"/>
-              <TextBlock Grid.Column="1" Text="{Binding Description}" VerticalAlignment="Center" Margin="10,0"/>
-              <ToggleSwitch Grid.Column="2" IsChecked="{Binding IsOn}" IsEnabled="{Binding IsEnabled}"/>
+            <Grid ColumnDefinitions="*,Auto" Margin="0,5">
+              <TextBlock Grid.Column="0" Text="{Binding Description}" VerticalAlignment="Center" Margin="10,0"/>
+              <ToggleSwitch Grid.Column="1" IsChecked="{Binding IsOn}" IsEnabled="{Binding IsEnabled}"/>
             </Grid>
           </DataTemplate>
         </ListBox.DataTemplates>

--- a/viewmodels/flagviewmodels.cs
+++ b/viewmodels/flagviewmodels.cs
@@ -7,7 +7,7 @@ namespace linuxblox.viewmodels
         public string Name { get; set; } = "";
         public string Description { get; set; } = "";
         
-        private bool _isEnabled;
+        private bool _isEnabled = true;
         public bool IsEnabled
         {
             get => _isEnabled;

--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -108,6 +108,8 @@ namespace linuxblox.viewmodels
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsDisablePostFX", Description = "Disable Post-Processing Effects", IsOn = false });
             Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", Value = "4" });
             Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID to enable visibility toggles (Ctrl+Shift+G, etc). Set to 0 to disable.", Value = "0" });
+            Flags.Add(new ToggleFlagViewModel { Name = "FFlagDisableNewIGMinDUA", Description = "Disable New In-Game Menu (Reverts to Old Menu)", IsOn = false });
+            Flags.Add(new ToggleFlagViewModel { Name = "FFlagEnableInGameMenuControls", Description = "Enable 'Controls' Button in In-Game Menu", IsOn = false });
         }
 
         private async Task<string> LoadSettingsFromFileAsync()
@@ -136,7 +138,7 @@ namespace linuxblox.viewmodels
                                 toggleFlag.IsOn = value.Equals("true", StringComparison.OrdinalIgnoreCase);
                             else if (flag is InputFlagViewModel inputFlag)
                                 inputFlag.Value = value;
-                        } else { flag.IsEnabled = false; }
+                        }
                     }
                 });
                 return "Sober config file loaded successfully.";


### PR DESCRIPTION
Removes the explicit checkbox from the UI for each flag item. Flags are now considered active and will be saved if they are defined in the application.

Changes include:
- Modified `mainwindow.axaml`:
  - Removed `CheckBox` elements from `DataTemplate`s for `InputFlagViewModel` and `ToggleFlagViewModel`.
  - Adjusted `Grid.ColumnDefinitions` and element column indices accordingly.
- Modified `viewmodels/flagviewmodels.cs`:
  - `FlagViewModel._isEnabled` now defaults to `true`.
- Modified `viewmodels/mainwindowviewmodel.cs`:
  - Removed logic in `LoadSettingsFromFileAsync` that would set `IsEnabled` to `false` if a flag was not found in the saved configuration.

This simplifies the UI and makes all listed flags configurable and saveable by default.