### PR TITLE
Fix: Correct InputFlagViewModel property access

### DIFF
--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -104,11 +104,11 @@ namespace linuxblox.viewmodels
         private void PopulateDefaultFlags()
         {
             Flags.Clear();
-            Flags.Add(new InputFlagViewModel { Name = "DFIntTaskSchedulerTargetFps", Description = "FPS Limit", Value = "144" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntTaskSchedulerTargetFps", Description = "FPS Limit", EnteredValue = "144" });
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsPreferVulkan", Description = "Prefer Vulkan Renderer", IsOn = true });
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsDisablePostFX", Description = "Disable Post-Processing Effects", IsOn = false });
-            Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", Value = "4" });
-            Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID to enable visibility toggles (Ctrl+Shift+G, etc). Set to 0 to disable.", Value = "0" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", EnteredValue = "4" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID to enable visibility toggles (Ctrl+Shift+G, etc). Set to 0 to disable.", EnteredValue = "0" });
         }
 
         private async Task<string> LoadSettingsFromFileAsync()
@@ -135,7 +135,7 @@ namespace linuxblox.viewmodels
                             if (flag is ToggleFlagViewModel toggleFlag)
                                 toggleFlag.IsOn = value.Equals("true", StringComparison.OrdinalIgnoreCase);
                             else if (flag is InputFlagViewModel inputFlag)
-                                inputFlag.Value = value;
+                                inputFlag.EnteredValue = value;
                         }
                     }
                 });
@@ -179,7 +179,7 @@ namespace linuxblox.viewmodels
                 if (flag is ToggleFlagViewModel toggle)
                     newFflags[flag.Name] = toggle.IsOn.ToString().ToLower();
                 else if (flag is InputFlagViewModel input)
-                    newFflags[flag.Name] = input.Value;
+                    newFflags[flag.Name] = input.EnteredValue;
             }
 
             configNode[FFlagsKey] = newFflags;


### PR DESCRIPTION
I replaced the erroneous `Value` property access with the correct `EnteredValue` property for `InputFlagViewModel` instances.

This resolves the following compilation errors:
- CS0117: 'InputFlagViewModel' does not contain a definition for 'Value'
- CS1656: Cannot assign to 'Value' because it is a 'method group'
- CS0428: Cannot convert method group 'Value' to non-delegate type 'JsonNode'

I made these changes in `viewmodels/mainwindowviewmodel.cs` in the `PopulateDefaultFlags`, `LoadSettingsFromFileAsync`, and `SaveChangesAsync` methods.