### PR TITLE
Fix 5 CA warnings to improve code quality and consistency.

### DIFF
--- a/core/robloxmanager.cs
+++ b/core/robloxmanager.cs
@@ -77,7 +77,18 @@ namespace linuxblox.core
                 var rawFlags = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonString) ?? new();
                 return rawFlags.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString() ?? "");
             }
-            catch { return new Dictionary<string, string>(); }
+            catch (JsonException)
+            {
+                return new Dictionary<string, string>();
+            }
+            catch (IOException)
+            {
+                return new Dictionary<string, string>();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
         }
 
         public static void WriteFlags(string path, Dictionary<string, string> flags)

--- a/program.cs
+++ b/program.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace linuxblox;
 
-class Program
+sealed class Program
 {
     [STAThread]
     public static void Main(string[] args) => BuildAvaloniaApp()

--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -13,6 +13,7 @@ using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace linuxblox.viewmodels
 {
@@ -117,7 +118,7 @@ namespace linuxblox.viewmodels
 
             try
             {
-                var jsonString = await File.ReadAllTextAsync(_soberConfigPath);
+                var jsonString = await File.ReadAllTextAsync(_soberConfigPath).ConfigureAwait(false);
                 if (string.IsNullOrWhiteSpace(jsonString)) return "Sober config is empty.";
 
                 var configNode = JsonNode.Parse(jsonString);
@@ -158,7 +159,7 @@ namespace linuxblox.viewmodels
 
             try
             {
-                var json = await File.ReadAllTextAsync(_soberConfigPath);
+                var json = await File.ReadAllTextAsync(_soberConfigPath).ConfigureAwait(false);
                 return string.IsNullOrWhiteSpace(json) ? new JsonObject() : JsonNode.Parse(json) ?? new JsonObject();
             }
             catch (Exception ex)
@@ -171,13 +172,13 @@ namespace linuxblox.viewmodels
         {
             if (string.IsNullOrEmpty(_soberConfigPath)) throw new InvalidOperationException("Config path not set.");
 
-            var configNode = await LoadOrCreateConfigNodeAsync();
+            var configNode = await LoadOrCreateConfigNodeAsync().ConfigureAwait(false);
 
             var newFflags = new JsonObject();
             foreach (var flag in Flags.Where(f => f.IsEnabled))
             {
                 if (flag is ToggleFlagViewModel toggle)
-                    newFflags[flag.Name] = toggle.IsOn.ToString().ToLower();
+                    newFflags[flag.Name] = toggle.IsOn.ToString().ToLowerInvariant();
                 else if (flag is InputFlagViewModel input)
                     newFflags[flag.Name] = input.EnteredValue;
             }
@@ -188,7 +189,7 @@ namespace linuxblox.viewmodels
             if (!string.IsNullOrEmpty(configDir)) Directory.CreateDirectory(configDir);
 
             var options = new JsonSerializerOptions { WriteIndented = true };
-            await File.WriteAllTextAsync(_soberConfigPath, configNode.ToJsonString(options));
+            await File.WriteAllTextAsync(_soberConfigPath, configNode.ToJsonString(options)).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Addresses the following Roslyn analyzer warnings:
- CA1031: Catch specific exceptions in RobloxManager.ReadFlags.
- CA1304 & CA1311: Use culture-invariant string operations in MainWindowViewModel.SaveChangesAsync.
- CA2007: Apply ConfigureAwait(false) to async calls in MainWindowViewModel (LoadSettingsFromFileAsync, SaveChangesAsync, LoadOrCreateConfigNodeAsync).
- CA1852: Seal the Program class as it has no subtypes.