### PR TITLE
Fix: Rename EnteredValue to Value in InputFlagViewModel

### DIFF
--- a/viewmodels/flagviewmodels.cs
+++ b/viewmodels/flagviewmodels.cs
@@ -13,8 +13,6 @@ namespace linuxblox.viewmodels
             get => _isEnabled;
             set => this.RaiseAndSetIfChanged(ref _isEnabled, value);
         }
-
-        public abstract string GetValue();
     }
 
     public class ToggleFlagViewModel : FlagViewModel
@@ -25,8 +23,6 @@ namespace linuxblox.viewmodels
             get => _isOn;
             set => this.RaiseAndSetIfChanged(ref _isOn, value);
         }
-
-        public override string GetValue() => IsOn.ToString();
     }
 
     public class InputFlagViewModel : FlagViewModel
@@ -37,7 +33,5 @@ namespace linuxblox.viewmodels
             get => _enteredValue;
             set => this.RaiseAndSetIfChanged(ref _enteredValue, value);
         }
-
-        public override string GetValue() => Value;
     }
 }

--- a/viewmodels/flagviewmodels.cs
+++ b/viewmodels/flagviewmodels.cs
@@ -32,12 +32,12 @@ namespace linuxblox.viewmodels
     public class InputFlagViewModel : FlagViewModel
     {
         private string _enteredValue = "";
-        public string EnteredValue
+        public string Value
         {
             get => _enteredValue;
             set => this.RaiseAndSetIfChanged(ref _enteredValue, value);
         }
 
-        public override string GetValue() => EnteredValue;
+        public override string GetValue() => Value;
     }
 }

--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -136,7 +136,7 @@ namespace linuxblox.viewmodels
                             if (flag is ToggleFlagViewModel toggleFlag)
                                 toggleFlag.IsOn = value.Equals("true", StringComparison.OrdinalIgnoreCase);
                             else if (flag is InputFlagViewModel inputFlag)
-                                inputFlag.Value = value;
+                                inputFlag.Value = value.Trim();
                         }
                     }
                 });

--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -182,7 +182,7 @@ namespace linuxblox.viewmodels
                 if (flag is ToggleFlagViewModel toggle)
                     newFflags[flag.Name] = toggle.IsOn.ToString().ToUpperInvariant();
                 else if (flag is InputFlagViewModel input)
-                    newFflags[flag.Name] = input.Value;
+                    newFflags[flag.Name] = input.Value.Trim();
             }
 
             configNode[FFlagsKey] = newFflags;

--- a/viewmodels/mainwindowviewmodel.cs
+++ b/viewmodels/mainwindowviewmodel.cs
@@ -105,11 +105,11 @@ namespace linuxblox.viewmodels
         private void PopulateDefaultFlags()
         {
             Flags.Clear();
-            Flags.Add(new InputFlagViewModel { Name = "DFIntTaskSchedulerTargetFps", Description = "FPS Limit", EnteredValue = "144" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntTaskSchedulerTargetFps", Description = "FPS Limit", Value = "144" });
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsPreferVulkan", Description = "Prefer Vulkan Renderer", IsOn = true });
             Flags.Add(new ToggleFlagViewModel { Name = "FFlagDebugGraphicsDisablePostFX", Description = "Disable Post-Processing Effects", IsOn = false });
-            Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", EnteredValue = "4" });
-            Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID to enable visibility toggles (Ctrl+Shift+G, etc). Set to 0 to disable.", EnteredValue = "0" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntPostEffectQualityLevel", Description = "Post Effect Quality (0-4)", Value = "4" });
+            Flags.Add(new InputFlagViewModel { Name = "DFIntCanHideGuiGroupId", Description = "Set to a Group ID to enable visibility toggles (Ctrl+Shift+G, etc). Set to 0 to disable.", Value = "0" });
         }
 
         private async Task<string> LoadSettingsFromFileAsync()
@@ -136,7 +136,7 @@ namespace linuxblox.viewmodels
                             if (flag is ToggleFlagViewModel toggleFlag)
                                 toggleFlag.IsOn = value.Equals("true", StringComparison.OrdinalIgnoreCase);
                             else if (flag is InputFlagViewModel inputFlag)
-                                inputFlag.EnteredValue = value;
+                                inputFlag.Value = value;
                         }
                     }
                 });
@@ -182,7 +182,7 @@ namespace linuxblox.viewmodels
                 if (flag is ToggleFlagViewModel toggle)
                     newFflags[flag.Name] = toggle.IsOn.ToString().ToUpperInvariant();
                 else if (flag is InputFlagViewModel input)
-                    newFflags[flag.Name] = input.EnteredValue;
+                    newFflags[flag.Name] = input.Value;
             }
 
             configNode[FFlagsKey] = newFflags;


### PR DESCRIPTION
The UI in mainwindow.axaml binds a TextBox to a property named 'Value' for InputFlagViewModel instances. This property was previously named 'EnteredValue', leading to a System.MissingMemberException.

This commit renames the 'EnteredValue' property to 'Value' in the InputFlagViewModel class and updates the associated GetValue() method to resolve the binding error.